### PR TITLE
20240308 두 인물비교 크롭화 기능 추가

### DIFF
--- a/comp_people.py
+++ b/comp_people.py
@@ -1,18 +1,26 @@
 from fastapi import FastAPI, File, UploadFile, Request, APIRouter
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.templating import Jinja2Templates
 from deepface.detectors import DetectorWrapper
 from deepface import DeepFace
 import numpy as np
 import cv2
+import io
 
-app = FastAPI()
 router = APIRouter()
 templates = Jinja2Templates(directory="view")
+
+
+def show_image(img, window_name):
+    cv2.imshow(window_name, img)
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()
 
 @router.get("/")
 async def read_root(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
 
+    
 @router.post("/people")
 async def compare_faces(file1: UploadFile = File(...), file2: UploadFile = File(...), file3: UploadFile = File(...)):
      
@@ -34,22 +42,56 @@ async def compare_faces(file1: UploadFile = File(...), file2: UploadFile = File(
     
     if len(faces1) > 1 or len(faces2) > 1 or len(faces3) > 1:
             return {"error": "한 이미지에 두 명 이상의 인물이 검출되었습니다."}
+        
+     # 얼굴 크롭 및 저장
+    def facial_area(img, detected_face):
+        # 가정: detected_face 객체의 facial_area 속성은 FacialAreaRegion 객체이며,
+        # 이 객체는 x, y, w, h 속성을 가진다.
+        x = detected_face.facial_area.x
+        y = detected_face.facial_area.y
+        w = detected_face.facial_area.w
+        h = detected_face.facial_area.h
+        return img[y:y+h, x:x+w]
+    
+    cropped_face1 = facial_area(img1, faces1[0])
+    cropped_face2 = facial_area(img2, faces2[0])
+    cropped_face3 = facial_area(img3, faces2[0])
+    
+
+
+    # 크롭된 얼굴 이미지와 결과를 반환
+    _, encoded_img1 = cv2.imencode('.png', cropped_face1)
+    _, encoded_img2 = cv2.imencode('.png', cropped_face2)
+    _, encoded_img3 = cv2.imencode('.png', cropped_face3)
+    encoded_img_bytes1 = encoded_img1.tobytes()
+    encoded_img_bytes2 = encoded_img2.tobytes()
+    encoded_img_bytes3 = encoded_img3.tobytes()
+    
+    # 크롭된 얼굴 이미지 표시
+    show_image(cropped_face1, "Cropped Face 1")
+    show_image(cropped_face2, "Cropped Face 2")
+    show_image(cropped_face3, "Cropped Face 3")
 
 
     try:
         # 첫 번째 이미지와 두 번째 이미지 비교
-        result1 = DeepFace.verify(img1, img2, model_name='Facenet512', detector_backend='dlib', distance_metric='euclidean')
+        result1 = DeepFace.verify(cropped_face1, cropped_face2, model_name='Facenet512', detector_backend='dlib', distance_metric='euclidean')
         
         # similarity_percent1 = int((1 - (result1['distance']/result1['threshold'])) * 100)
 
         # 첫 번째 이미지와 세 번째 이미지 비교
-        result2 = DeepFace.verify(img1, img3, model_name='Facenet512', detector_backend='dlib', distance_metric='euclidean')
+        result2 = DeepFace.verify(cropped_face1, cropped_face3, model_name='Facenet512', detector_backend='dlib', distance_metric='euclidean')
         
         # similarity_percent2 = int((1 - (result2['distance']/result2['threshold'])) * 100)          
         
 
-        return {"result1": result1, "result2": result2}
+        return {
+            "face1": FileResponse(io.BytesIO(encoded_img_bytes1), media_type='image/png'),
+            "face2": FileResponse(io.BytesIO(encoded_img_bytes2), media_type='image/png'),
+            "face3": FileResponse(io.BytesIO(encoded_img_bytes3), media_type='image/png'),
+            "result1": result1, 
+            "result2": result2}
 
     
     except Exception as e:
-        return {"error": str(e)}
+        return JSONResponse(content={"error": str(e)}, status_code=500)


### PR DESCRIPTION
## 작업 분류
* * *
- 관련있는 이슈 번호 넣어주세요(예시: #54)

## PR 타입
* * *
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

## 개요
* * *
- 검출된 인물 크롭화 기능

## 변경 사항
* * *
- 검출된 인물 크롭화 기능 추가

## 코드 리뷰시 참고 사항
* * *
 ```
# 얼굴 크롭 및 저장
    def facial_area(img, detected_face):
        # 가정: detected_face 객체의 facial_area 속성은 FacialAreaRegion 객체이며,
        # 이 객체는 x, y, w, h 속성을 가진다.
        x = detected_face.facial_area.x
        y = detected_face.facial_area.y
        w = detected_face.facial_area.w
        h = detected_face.facial_area.h
        return img[y:y+h, x:x+w]
    
    cropped_face1 = facial_area(img1, faces1[0])
    cropped_face2 = facial_area(img2, faces2[0])
    cropped_face3 = facial_area(img3, faces2[0])
```
- 검출한 이미지 크롭 기능

## 테스트 결과
* * *
![스크린샷 2024-03-04 124418](https://github.com/TEAM-MUJAE/Face_AI_Model_Service_AI_Serving/assets/148633060/a12b2c9d-c0f2-4398-a85d-0ea0cc743cc5)


## 요청 사항
* * *
- 크롭된 이미지 임시 폴더 이동 추가 예정
- 랜드마크 기능 추가 예정